### PR TITLE
Support for resource maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ justCopy:
 ```
 
 * `paths`: Can be either a list of file or folder paths or an object with src dest attributes:
-  ```
+```
    {
       src: "some/relative/src"
       dest: "some/relative/dest"
-    }```
+    }
+```
 * The contents of `paths` will only be copied from the `watch.sourceDir` to the `watch.compiledDir`. Paths can be relative to watch.sourceDir or absolute.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,10 @@ justCopy:
   paths:[]
 ```
 
-* `paths`: A list of strings, files or folder paths, the contents of which Mimosa will only copy from the `watch.sourceDir` to the `watch.compiledDir`. Paths can be relative to watch.sourceDir or absolute.
+* `paths`: Can be either a list of file or folder paths or an object with src dest attributes:
+  ```
+   {
+      src: "some/relative/src"
+      dest: "some/relative/dest"
+    }```
+* The contents of `paths` will only be copied from the `watch.sourceDir` to the `watch.compiledDir`. Paths can be relative to watch.sourceDir or absolute.

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,14 +8,23 @@ exports.defaults = function() {
 };
 
 exports.placeholder = function() {
-  return "\t\n\n  justCopy:     # Configuration for the just-copy module\n    paths:[]    # List of file or folder paths, the contents of which Mimosa will only copy\n                # from the watch.sourceDir to the watch.compiledDir. Paths can be relative\n                # to watch.sourceDir or absolute.";
+  return "\t\n\n  justCopy:     # Configuration for the just-copy module\n    paths:[]    # Can be either a list of file or folder paths or an object with src dest attributes:\n                #   {\n                #     src: \"some/relative/src\"\n                #     dest: \"some/relative/dest\"\n                #   }\n                #\n                # The contents of this array will only be copied\n                # from the watch.sourceDir to the watch.compiledDir. Paths can be relative\n                # to watch.sourceDir or absolute.";
 };
 
 exports.validate = function(config, validators) {
-  var errors;
+  var errors, path, _i, _len, _ref;
   errors = [];
   if (validators.ifExistsIsObject(errors, "justCopy config", config.justCopy)) {
-    validators.ifExistsArrayOfMultiPaths(errors, "justCopy.paths", config.justCopy.paths, config.watch.sourceDir);
+    _ref = config.justCopy.paths;
+    for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+      path = _ref[_i];
+      if (typeof path === "object") {
+        validators.ifExistsIsString(errors, "justCopy.paths:src", path.src);
+        validators.ifExistsIsString(errors, "justCopy.paths:dest", path.dest);
+      } else {
+        validators.ifExistsIsString(errors, "justCopy.paths", path);
+      }
+    }
   }
   return errors;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,10 @@
 "use strict";
-var config, fs, logger, registration, _checkForRemoveAllFiles, _placeFilesIntoWorkflow, _removeExtensionFileAndEndWorkflow, _removeFile, _removeFileAndEndWorkflow, _removeFileFromWorkflow, _removeFilesFromWorkflow,
+var config, fs, logger, registration, _, _checkForRemoveAllFiles, _placeFilesIntoWorkflow, _removeExtensionFileAndEndWorkflow, _removeFile, _removeFileAndEndWorkflow, _removeFileFromWorkflow, _removeFilesFromWorkflow,
   __slice = [].slice;
 
 fs = require('fs');
+
+_ = require('underscore');
 
 config = require('./config');
 
@@ -20,7 +22,7 @@ registration = function(mimosaConfig, register) {
 };
 
 _removeFilesFromWorkflow = function(mimosaConfig, options, next) {
-  var file, folder, i, index, indices, numFiles, _i, _j, _k, _len, _len1, _len2, _ref, _ref1;
+  var dest, entry, file, folder, i, index, indices, numFiles, src, _i, _j, _k, _len, _len1, _len2, _ref, _ref1;
   if (!options.files) {
     return next();
   }
@@ -34,8 +36,9 @@ _removeFilesFromWorkflow = function(mimosaConfig, options, next) {
     file = _ref[i];
     _ref1 = mimosaConfig.justCopy.paths;
     for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
-      folder = _ref1[_j];
-      if (file.inputFileName.indexOf(folder) === 0) {
+      entry = _ref1[_j];
+      folder = _.isString(entry) ? entry : entry.src;
+      if (file.inputFileName.indexOf(folder) !== -1) {
         indices.unshift(i);
         break;
       }
@@ -43,22 +46,28 @@ _removeFilesFromWorkflow = function(mimosaConfig, options, next) {
   }
   for (_k = 0, _len2 = indices.length; _k < _len2; _k++) {
     index = indices[_k];
-    _removeFileFromWorkflow(options, index);
+    src = entry.src ? mimosaConfig.watch.sourceDir + "/" + entry.src : mimosaConfig.watch.sourceDir;
+    dest = entry.dest ? mimosaConfig.watch.compiledDir + "/" + entry.dest : mimosaConfig.watch.compiledDir;
+    _removeFileFromWorkflow(options, index, src, dest);
   }
   return next();
 };
 
-_removeFileFromWorkflow = function(options, index) {
+_removeFileFromWorkflow = function(options, index, src, dest) {
   var removed;
   if (!options.justCopyFiles) {
     options.justCopyFiles = [];
   }
   removed = options.files.splice(index, 1);
-  return options.justCopyFiles.push(removed[0]);
+  return options.justCopyFiles.push({
+    copyFile: removed[0],
+    src: src,
+    dest: dest
+  });
 };
 
 _placeFilesIntoWorkflow = function(mimosaConfig, options, next) {
-  var copyFile, _i, _len, _ref;
+  var copyFile, dest, entry, oldFilename, src, _i, _len, _ref;
   if (!options.justCopyFiles) {
     return next();
   }
@@ -67,8 +76,11 @@ _placeFilesIntoWorkflow = function(mimosaConfig, options, next) {
   }
   _ref = options.justCopyFiles;
   for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-    copyFile = _ref[_i];
-    copyFile.outputFileName = copyFile.inputFileName.replace(mimosaConfig.watch.sourceDir, mimosaConfig.watch.compiledDir);
+    entry = _ref[_i];
+    copyFile = entry.copyFile, src = entry.src, dest = entry.dest;
+    oldFilename = copyFile.inputFileName;
+    copyFile.outputFileName = copyFile.inputFileName.replace(src, dest);
+    logger.debug("Moving " + oldFilename + " to " + copyFile.outputFileName);
     copyFile.outputFileText = copyFile.inputFileText;
     options.files.push(copyFile);
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "mmodule",
     "copy"
   ],
+  "dependencies": {
+    "underscore": "1.6.0"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=0.10"

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -9,7 +9,13 @@ exports.placeholder = ->
   \t
 
     justCopy:     # Configuration for the just-copy module
-      paths:[]    # List of file or folder paths, the contents of which Mimosa will only copy
+      paths:[]    # Can be either a list of file or folder paths or an object with src dest attributes:
+                  #   {
+                  #     src: "some/relative/src"
+                  #     dest: "some/relative/dest"
+                  #   }
+                  #
+                  # The contents of this array will only be copied
                   # from the watch.sourceDir to the watch.compiledDir. Paths can be relative
                   # to watch.sourceDir or absolute.
   """
@@ -17,5 +23,10 @@ exports.placeholder = ->
 exports.validate = (config, validators) ->
   errors = []
   if validators.ifExistsIsObject(errors, "justCopy config", config.justCopy)
-    validators.ifExistsArrayOfMultiPaths(errors, "justCopy.paths", config.justCopy.paths, config.watch.sourceDir);
+    for path in config.justCopy.paths
+      if typeof path is "object"
+        validators.ifExistsIsString(errors, "justCopy.paths:src", path.src)
+        validators.ifExistsIsString(errors, "justCopy.paths:dest", path.dest)
+      else
+        validators.ifExistsIsString(errors, "justCopy.paths", path)
   errors


### PR DESCRIPTION
Hey David, 

We're using just copy to solve a problem staging some css resources from the ace editor. Ace wants to fetch its own stylesheets and expects them to be co-located with the javascript. 

I modified the just-copy plugin to support this use case by allowing you to specify both a source and a destination, rather than just a source. 

You can add it to your config with something like the following: 

```
  justCopy:
    paths:[
      {
        src: "stylesheets/vendor/ace"
        dest: "javascripts/vendor/ace"
      }
    ]
```
